### PR TITLE
add admin pass secret

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -20,3 +20,5 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+2. Get the admin password by running this command:
+  kubectl -n {{ .Release.Namespace }} get secret nso-auth -o go-template='{{ "{{" }}.data.adminPassword | base64decode{{ "}}" }}{{ "{{" }}printf "\n"{{ "}}" }}'

--- a/templates/auth-secret.yaml
+++ b/templates/auth-secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "nso-auth"
+type: Opaque
+data:
+{{- if empty .Values.adminPassword }}
+  # retrieve the secret data using lookup function and when not exists, return an empty dictionary / map as result
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "nso-auth") | default dict }}
+  {{- $secretData := (get $secretObj "data") | default dict }}
+  # set $nso-auth to existing secret data or generate a random one when not exists
+  {{- $nsoAuth := (get $secretData "adminPassword") | default (randAlphaNum 16 | b64enc) }}
+  adminPassword: {{ $nsoAuth | quote }}
+{{- else }}
+  adminPassword: {{ .Values.adminPassword | b64enc }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,7 +37,10 @@ spec:
           - name: ADMIN_USERNAME
             value: "{{ .Values.adminUsername }}"
           - name: ADMIN_PASSWORD
-            value: "{{ .Values.adminPassword }}"
+            valueFrom:
+              secretKeyRef:
+                name: nso-auth
+                key: adminPassword  
           - name: HTTP_ENABLE
             value: "{{ .Values.httpEnable }}"
           - name: HTTPS_ENABLE

--- a/values.yaml
+++ b/values.yaml
@@ -4,13 +4,16 @@
 
 # NSO-specific variables
 adminUsername: admin
-adminPassword: admin
 httpEnable: "true"
 httpsEnable: "false"
 sshPort: "22"
 cliStyle: c
 haEnable: "false"
 pamEnable: "false"
+
+# template will auto generate an admin password
+# to manually set password, uncomment adminPassword below
+# adminPassword: admin
 
 replicaCount: 1
 


### PR DESCRIPTION
Added feature - autogenerate admin password and load it into a secret. 
This will accept a user manually defining a password as well. 